### PR TITLE
Add support for conditional statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The target `tool` has been successfully built in Ubuntu, make sure the executabl
 
 ```sh
 # Required for all targets
-sudo apt install flang-20 libflang-20-dev llvm-20-dev libmlir-20-dev mlir-20-tools
+sudo apt install flang-20 libflang-20-dev clang-20 libclang-20-dev llvm-20-dev libmlir-20-dev mlir-20-tools
 ```
 ## WSL Support
 
 Flang 20 requires at least Ubuntu 25.04. If this distribuition is not available in WSL, you can follow these steps:
 
-- Get the [WSL image](https://releases.ubuntu.com/plucky/) 
+- Get the [WSL image](https://releases.ubuntu.com/plucky/)
 - Import the downloaded image, e.g., `wsl --import "Ubuntu25.04" <install_path> ubuntu-25.04-wsl-amd64.wsl`
 - You can check if it is installed with `wsl -l -v`
 - Execute the distribution with `wsl -d Ubuntu25.04`

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -146,7 +146,7 @@ void dump(const Fortran::parser::Scalar<Fortran::parser::Integer<Fortran::parser
 
 template <typename T>
 void dump(const Fortran::parser::Scalar<T> &v, const char *property_name) {
-    dump(v.thing, property_name);
+    dump(v.thing, "value");
 }
 
 template <typename T>

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -144,6 +144,16 @@ void dump(const Fortran::parser::Scalar<Fortran::parser::Integer<Fortran::parser
     dump(v.thing.thing.thing.source, property_name);
 }
 
+template <typename T>
+void dump(const Fortran::parser::Scalar<T> &v, const char *property_name) {
+    dump(v.thing, property_name);
+}
+
+template <typename T>
+void dump(const Fortran::parser::Logical<T> &v, const char *property_name) {
+    dump(v.thing, property_name);
+}
+
 void dump(const Fortran::parser::Sign &v, const char *property_name) {
     switch(v) {
         case Fortran::parser::Sign::Positive:
@@ -632,10 +642,7 @@ public:
   DUMP_NODE(Fortran::parser::IfConstruct::ElseBlock, {})
   DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, {})
   DUMP_NODE(Fortran::parser::IfStmt, {})
-  DUMP_NODE_MANUAL(Fortran::parser::IfThenStmt, {
-    dump(std::get<0>(v.t), "ifConstructName");
-    dump(std::get<1>(v.t).thing.thing, "condition");
-  })
+  DUMP_NODE(Fortran::parser::IfThenStmt, {})
   DUMP_NODE(Fortran::parser::TeamValue, {})
   DUMP_NODE(Fortran::parser::ImageSelector, {})
   DUMP_NODE(Fortran::parser::ImageSelectorSpec, {})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -645,7 +645,7 @@ public:
   DUMP_NODE(Fortran::parser::IdVariable, {})
   DUMP_NODE(Fortran::parser::IfConstruct, {})
   DUMP_NODE(Fortran::parser::IfConstruct::ElseBlock, {})
-  DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, { dump(std::get<0>(std::get<0>(v.t).statement.t), "condition"); })
+  DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, {})
   DUMP_NODE(Fortran::parser::IfStmt, {})
   DUMP_NODE(Fortran::parser::IfThenStmt, {})
   DUMP_NODE(Fortran::parser::TeamValue, {})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -154,6 +154,11 @@ void dump(const Fortran::parser::Logical<T> &v, const char *property_name) {
     dump(v.thing, property_name);
 }
 
+template <typename T>
+void dump(const Fortran::parser::Integer<T> &v, const char *property_name) {
+    dump(v.thing, property_name);
+}
+
 void dump(const Fortran::parser::Sign &v, const char *property_name) {
     switch(v) {
         case Fortran::parser::Sign::Positive:

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -645,7 +645,7 @@ public:
   DUMP_NODE(Fortran::parser::IdVariable, {})
   DUMP_NODE(Fortran::parser::IfConstruct, {})
   DUMP_NODE(Fortran::parser::IfConstruct::ElseBlock, {})
-  DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, {})
+  DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, { dump(std::get<0>(std::get<0>(v.t).statement.t), "condition"); })
   DUMP_NODE(Fortran::parser::IfStmt, {})
   DUMP_NODE(Fortran::parser::IfThenStmt, {})
   DUMP_NODE(Fortran::parser::TeamValue, {})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -241,7 +241,7 @@ void dump(const Fortran::common::Indirection<T> &v) {
 
 
 void dump(const Fortran::parser::Expr &v) {
-  dump(v.u);  
+  dump(v.u);
 }
 
 template <typename T>
@@ -632,7 +632,10 @@ public:
   DUMP_NODE(Fortran::parser::IfConstruct::ElseBlock, {})
   DUMP_NODE(Fortran::parser::IfConstruct::ElseIfBlock, {})
   DUMP_NODE(Fortran::parser::IfStmt, {})
-  DUMP_NODE(Fortran::parser::IfThenStmt, {})
+  DUMP_NODE_MANUAL(Fortran::parser::IfThenStmt, {
+    dump(std::get<0>(v.t), "ifConstructName");
+    dump(std::get<1>(v.t).thing.thing, "condition");
+  })
   DUMP_NODE(Fortran::parser::TeamValue, {})
   DUMP_NODE(Fortran::parser::ImageSelector, {})
   DUMP_NODE(Fortran::parser::ImageSelectorSpec, {})

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -70,6 +70,10 @@ template <typename... T>
 void dump(const std::tuple<T...> &v);
 void dump(const Fortran::parser::Expr &v);
 void dump(const Fortran::parser::Scalar<Fortran::parser::Integer<Fortran::parser::Constant<Fortran::parser::Name>>> &v, const char *property_name);
+template <typename T>
+void dump(const Fortran::parser::Scalar<T> &v, const char *property_name);
+template <typename T>
+void dump(const Fortran::parser::Logical<T> &v, const char *property_name);
 void dump(const Fortran::parser::Sign &v, const char *property_name);
 
 

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -74,6 +74,8 @@ template <typename T>
 void dump(const Fortran::parser::Scalar<T> &v, const char *property_name);
 template <typename T>
 void dump(const Fortran::parser::Logical<T> &v, const char *property_name);
+template <typename T>
+void dump(const Fortran::parser::Integer<T> &v, const char *property_name);
 void dump(const Fortran::parser::Sign &v, const char *property_name);
 
 


### PR DESCRIPTION
# Description

Adds a few changes that allow dumping the necessary information for the implementation of if constructs in the transpiler, as well as other changes.

# Changes Made

- Added new overloads of `dump()` for `Scalar`, `Logical` and `Integer`, allowing the AST in the transpiler to stay linked with its children as well as skip these nodes (since they are not relevant)
- Fixed the dependencies reported in the README