### PR TITLE
Improve dump structure

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -749,7 +749,7 @@ public:
   })
 
   DUMP_NODE_MANUAL(Fortran::parser::LoopControl::Bounds, {dump(v.name.thing, "var"); dump(v.lower.thing, "lower"); dump(v.upper.thing, "upper"); if(v.step.has_value()) dump(v.step.value().thing, "step");})
-  DUMP_NODE_MANUAL(Fortran::parser::LoopControl, {if (v.u.index() == 1) {dump(std::get<1>(v.u).thing.thing, "value"); dump("While", "kind");} else {dumpUnion(v); dump(v.u.index() == 0 ? "Range" : "Concurrent", "kind");}})
+  DUMP_NODE(Fortran::parser::LoopControl, {})
   DUMP_NODE(Fortran::parser::LoopControl::Concurrent, {})
   DUMP_NODE(Fortran::parser::MainProgram, {})
   DUMP_NODE(Fortran::parser::Map, {})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -104,7 +104,10 @@ template <> std::string getId(const std::nullopt_t &) { return "null"; }
 
 struct variant_visitor {
   template <typename T> void operator()(const T &value) const {
-    dump(value, "value");
+    const char *valueName = getNodeName(value);
+
+    dump(valueName, "variantType");
+    dump(value, valueName);
   }
 };
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -186,11 +186,7 @@ void dump(const Fortran::parser::CharBlock &v, const char *property_name) {
 }
 
 template <> void dump(const std::nullopt_t &v, const char *property_name) {
-  if (!strcmp(property_name, "null")) {
-    return;
-  }
-
-  dump("null", property_name);
+  // No need to dump anything
 }
 
 template <typename T>

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -106,7 +106,7 @@ struct variant_visitor {
   template <typename T> void operator()(const T &value) const {
     const char *valueName = getNodeName(value);
 
-    dump(valueName, "variantType");
+    dump(valueName, "variantKey");
     dump(value, valueName);
   }
 };


### PR DESCRIPTION
# Description

Closes #20. Performs two improvements on the structure of the dump generated:

- When an `std::optional` is set to `std::nullopt`, no value will be dumped instead of dumping the "null" string
- When an `std::variant` is dumped, instead of dumping it with the `"value"` key, it is dumped with the type of the wrapped value, contained in a new `"variantKey"` attribute

