### PR TITLE
Add comment dumping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 # Build plugin
 #add_library(plugin MODULE ${SOURCE_FILES} src/plugin.cpp)
 
-add_library(DumpASTPlugin MODULE src/plugin.cpp)
+add_library(DumpASTPlugin MODULE src/comments.cpp src/plugin.cpp)
 
 # Avoid lib prefix so that Flang finds the plugin as `DumpParseTreePlugin.so`, not `libDumpParseTreePlugin.so`
 set_target_properties(DumpASTPlugin PROPERTIES PREFIX "")

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -8,7 +8,8 @@ inline std::string_view trim(const std::string_view& s)
 {
     size_t start = s.find_first_not_of(" \t");
     size_t end = s.find_last_not_of(" \t") + 1;
-    return s.substr(start, end - start);
+
+    return start < end ? s.substr(start, end - start) : std::string_view();
 }
 
 inline std::string escapeComment(const std::string_view& s)

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -59,16 +59,14 @@ std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file)
     return comments;
 }
 
-Comment processComment(const RawComment &rawComment, const std::string &parentId, const std::string &beforeId) {
+Comment processComment(const RawComment &rawComment, const std::string &lastStmtId) {
     return Comment {
         rawComment.text,
-        parentId,
-        beforeId
+        lastStmtId
     };
 }
 
 std::string toString(const Comment &comment) {
     return "{\"text\": \"" + comment.text +
-           "\", \"parentId\": \"" + comment.parentId +
-           "\", \"beforeId\": \"" + comment.beforeId + "\"}";
+           "\", \"stmtId\": \"" + comment.stmtId + "\"}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -60,7 +60,6 @@ std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file)
 
 Comment processComment(const RawComment &rawComment, const std::string &parentId, const std::string &beforeId) {
     return Comment {
-        rawComment.line,
         rawComment.text,
         parentId,
         beforeId
@@ -68,8 +67,7 @@ Comment processComment(const RawComment &rawComment, const std::string &parentId
 }
 
 std::string toString(const Comment &comment) {
-    return "{\"line\": " + std::to_string(comment.line) +
-           ", \"text\": \"" + comment.text + "\"," +
+    return "{\"text\": \"" + comment.text + "\"," +
            ", \"parentId\": \"" + comment.parentId + "\"," +
            ", \"beforeId\": \"" + comment.beforeId + "\"}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -1,0 +1,41 @@
+#include "comments.h"
+
+#include "flang/Parser/parse-tree.h"
+
+std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file) {
+    llvm::ArrayRef<char> content = file.content();
+    std::vector<Comment> comments;
+
+    for (size_t i = 1; i <= file.lines(); i++) {
+        std::size_t start = file.GetLineStartOffset(i);
+
+        std::size_t end = start;
+        while (end < content.size() && content[end] != '\n')
+            end++;
+
+        std::string_view line(content.data() + start, end - start);
+
+        comments.push_back(Comment{i, start + 1, line});
+    }
+
+    return comments;
+}
+
+std::string escapeQuotes(std::string_view sv) {
+    std::string out;
+    out.reserve(sv.size());
+
+    for (char c : sv) {
+        if (c == '"')
+            out += "\\\"";
+        else
+            out += c;
+    }
+    return out;
+}
+
+std::string toString(const Comment &comment) {
+    return "{\"line\": " + std::to_string(comment.line) +
+           ", \"column\": " + std::to_string(comment.column) +
+           ", \"text\": \"" + escapeQuotes(comment.text) + "\"}";
+}

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -28,12 +28,22 @@ inline std::string escapeComment(const std::string_view& s)
     return result;
 }
 
+inline std::string toUppercase(const std::string_view& s)
+{
+    std::string result;
+    result.reserve(s.size());
+    for (char c : s) {
+        result += std::toupper(c);
+    }
+    return result;
+}
+
 std::optional<std::string> extractCommentFromLine(std::string_view line) {
     std::string_view trimmedLine = trim(line);
 
     if (trimmedLine.size() > 0 && trimmedLine[0] == '!') {
         // Ignore OpenMP directives
-        if (trimmedLine.size() >= 5 && trimmedLine.substr(1, 5) == "$OMP") {
+        if (trimmedLine.size() >= 5 && toUppercase(trimmedLine.substr(1, 4)) == "$OMP") {
             return std::nullopt;
         }
 

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -5,16 +5,6 @@
 
 #include "flang/Parser/parse-tree.h"
 
-inline std::string toUppercase(const std::string_view& s)
-{
-    std::string result;
-    result.reserve(s.size());
-    for (char c : s) {
-        result += std::toupper(c);
-    }
-    return result;
-}
-
 // Extracts a comment from a line, using a state machine
 std::optional<std::string> extractCommentFromLine(std::string_view line) {
     // Add more if needed
@@ -23,15 +13,20 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
     };
 
     std::string comment;
+    std::string uppercaseComment;  // For checking directives
     bool inComment = false;
     char quote = '\0';
 
     for (char c: line) {
         if (inComment) {
             // Escape JSON special characters
-            if (c == '"' || c == '\\')
+            if (c == '"' || c == '\\') {
                 comment += '\\';
+                uppercaseComment += '\\';
+            }
             comment += c;
+            uppercaseComment += std::toupper(c);
+
         } else if (quote == '\0' && (c == '\'' || c == '"')) {
             quote = c;
         } else if (quote != '\0' && c == quote) {
@@ -39,11 +34,13 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
         } else if (c == '!' && quote == '\0') {
             inComment = true;
             comment += '!';
+            uppercaseComment += '!';
         }
 
         // Ignore directives
-        if (DIRECTIVE_PREFIXES.count(comment) > 0) {
+        if (DIRECTIVE_PREFIXES.count(uppercaseComment) > 0) {
             comment.clear();
+            uppercaseComment.clear();
             inComment = false;
         }
     }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -68,7 +68,7 @@ Comment processComment(const RawComment &rawComment, const std::string &parentId
 }
 
 std::string toString(const Comment &comment) {
-    return "{\"text\": \"" + comment.text + "\"," +
-           ", \"parentId\": \"" + comment.parentId + "\"," +
-           ", \"beforeId\": \"" + comment.beforeId + "\"}";
+    return "{\"text\": \"" + comment.text +
+           "\", \"parentId\": \"" + comment.parentId +
+           "\", \"beforeId\": \"" + comment.beforeId + "\"}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -24,8 +24,7 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
 
     std::string comment;
     bool inComment = false;
-    bool inQuote = false;
-    bool charEscaped = false;
+    char quote = '\0';
 
     for (char c: line) {
         if (inComment) {
@@ -33,9 +32,11 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
             if (c == '"' || c == '\\')
                 comment += '\\';
             comment += c;
-        } else if (c == '"' && !charEscaped) {
-            inQuote = !inQuote;
-        } else if (c == '!' && !inQuote) {
+        } else if (quote == '\0' && (c == '\'' || c == '"')) {
+            quote = c;
+        } else if (quote != '\0' && c == quote) {
+            quote = '\0';
+        } else if (c == '!' && quote == '\0') {
             inComment = true;
             comment += '!';
         }
@@ -43,8 +44,6 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
         if (DIRECTIVE_PREFIXES.count(comment) > 0) {
             comment.clear();
         }
-
-        charEscaped = c == '\\';
     }
 
     return comment.empty() ? std::nullopt : std::optional<std::string>(comment);

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -5,30 +5,6 @@
 
 #include "flang/Parser/parse-tree.h"
 
-inline std::string_view trim(const std::string_view& s)
-{
-    size_t start = s.find_first_not_of(" \t");
-    size_t end = s.find_last_not_of(" \t") + 1;
-
-    return start < end ? s.substr(start, end - start) : std::string_view();
-}
-
-inline std::string escapeComment(const std::string_view& s)
-{
-    std::string result;
-    result.reserve(s.size());
-    for (char c : s) {
-        if (c == '"') {
-            result += "\\\"";
-        } else if (c == '\\') {
-            result += "\\\\";
-        } else {
-            result += c;
-        }
-    }
-    return result;
-}
-
 inline std::string toUppercase(const std::string_view& s)
 {
     std::string result;
@@ -39,24 +15,39 @@ inline std::string toUppercase(const std::string_view& s)
     return result;
 }
 
+// Extracts a comment from a line, using a state machine
 std::optional<std::string> extractCommentFromLine(std::string_view line) {
     // Add more if needed
     static const std::unordered_set<std::string> DIRECTIVE_PREFIXES = {
-        "$OMP", "$ACC", "DIR$", "DEC$", "GCC$"
+        "!$OMP", "!$ACC", "!DIR$", "!DEC$", "!GCC$"
     };
 
-    std::string_view trimmedLine = trim(line);
+    std::string comment;
+    bool inComment = false;
+    bool inQuote = false;
+    bool charEscaped = false;
 
-    if (trimmedLine.size() > 0 && trimmedLine[0] == '!') {
-        // Ignore directives
-        if (trimmedLine.size() >= 5 && DIRECTIVE_PREFIXES.count(toUppercase(trimmedLine.substr(1, 4))) == 1) {
-            return std::nullopt;
+    for (char c: line) {
+        if (inComment) {
+            // Escape JSON special characters
+            if (c == '"' || c == '\\')
+                comment += '\\';
+            comment += c;
+        } else if (c == '"' && !charEscaped) {
+            inQuote = !inQuote;
+        } else if (c == '!' && !inQuote) {
+            inComment = true;
+            comment += '!';
         }
 
-        return escapeComment(trimmedLine);
-    } else {
-        return std::nullopt;
+        if (DIRECTIVE_PREFIXES.count(comment) > 0) {
+            comment.clear();
+        }
+
+        charEscaped = c == '\\';
     }
+
+    return comment.empty() ? std::nullopt : std::optional<std::string>(comment);
 }
 
 std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file) {

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -1,6 +1,41 @@
 #include "comments.h"
 
+#include <optional>
+
 #include "flang/Parser/parse-tree.h"
+
+inline std::string_view trim(const std::string_view& s)
+{
+    size_t start = s.find_first_not_of(" \t");
+    size_t end = s.find_last_not_of(" \t") + 1;
+    return s.substr(start, end - start);
+}
+
+inline std::string escapeComment(const std::string_view& s)
+{
+    std::string result;
+    result.reserve(s.size());
+    for (char c : s) {
+        if (c == '"') {
+            result += "\\\"";
+        } else if (c == '\\') {
+            result += "\\\\";
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+std::optional<std::string> extractCommentFromLine(std::string_view line) {
+    std::string_view trimmedLine = trim(line);
+
+    if (trimmedLine.size() > 0 && trimmedLine[0] == '!') {
+        return escapeComment(trimmedLine);
+    } else {
+        return std::nullopt;
+    }
+}
 
 std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file) {
     llvm::ArrayRef<char> content = file.content();
@@ -13,29 +48,18 @@ std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file) {
         while (end < content.size() && content[end] != '\n')
             end++;
 
-        std::string_view line(content.data() + start, end - start);
+        std::optional<std::string> line = extractCommentFromLine(std::string_view(content.data() + start, end - start));
 
-        comments.push_back(Comment{i, start + 1, line});
+        if (line.has_value()) {
+            comments.push_back(Comment{i, start + 1, line.value()});
+        }
     }
 
     return comments;
 }
 
-std::string escapeQuotes(std::string_view sv) {
-    std::string out;
-    out.reserve(sv.size());
-
-    for (char c : sv) {
-        if (c == '"')
-            out += "\\\"";
-        else
-            out += c;
-    }
-    return out;
-}
-
 std::string toString(const Comment &comment) {
     return "{\"line\": " + std::to_string(comment.line) +
            ", \"column\": " + std::to_string(comment.column) +
-           ", \"text\": \"" + escapeQuotes(comment.text) + "\"}";
+           ", \"text\": \"" + comment.text + "\"}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -6,7 +6,7 @@
 #include "flang/Parser/parse-tree.h"
 
 // Extracts a comment from a line, using a state machine
-std::optional<std::string> extractCommentFromLine(std::string_view line) {
+std::tuple<std::optional<std::string>, size_t> extractCommentFromLine(std::string_view line) {
     // Add more if needed
     static const std::unordered_set<std::string> DIRECTIVE_PREFIXES = {
         "!$OMP", "!$ACC", "!DIR$", "!DEC$", "!GCC$"
@@ -16,6 +16,7 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
     std::string uppercaseComment;  // For checking directives
     bool inComment = false;
     char quote = '\0';
+    size_t sepsBefore = 0;
 
     for (char c: line) {
         if (inComment) {
@@ -27,14 +28,18 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
             comment += c;
             uppercaseComment += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
-        } else if (quote == '\0' && (c == '\'' || c == '"')) {
-            quote = c;
+        } else if (quote == '\0') {
+            if (c == '!') {
+                inComment = true;
+                comment += '!';
+                uppercaseComment += '!';
+            } else if (c == ';') {
+                sepsBefore++;
+            } else if (c == '"' || c == '\'') {
+                quote = c;
+            }
         } else if (quote != '\0' && c == quote) {
             quote = '\0';
-        } else if (c == '!' && quote == '\0') {
-            inComment = true;
-            comment += '!';
-            uppercaseComment += '!';
         }
 
         // Ignore directives
@@ -45,7 +50,8 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
         }
     }
 
-    return comment.empty() ? std::nullopt : std::optional<std::string>(comment);
+    auto commentOpt = comment.empty() ? std::nullopt : std::optional<std::string>(comment);
+    return std::make_tuple(commentOpt, sepsBefore);
 }
 
 std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file) {
@@ -59,10 +65,10 @@ std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file)
         while (end < content.size() && content[end] != '\n')
             end++;
 
-        std::optional<std::string> line = extractCommentFromLine(std::string_view(content.data() + start, end - start));
+        auto [commentOpt, sepsBefore] = extractCommentFromLine(std::string_view(content.data() + start, end - start));
 
-        if (line.has_value()) {
-            comments.push_back(RawComment{i, line.value()});
+        if (commentOpt.has_value()) {
+            comments.push_back(RawComment{i, commentOpt.value(), sepsBefore});
         }
     }
 

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -41,8 +41,10 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
             comment += '!';
         }
 
+        // Ignore directives
         if (DIRECTIVE_PREFIXES.count(comment) > 0) {
             comment.clear();
+            inComment = false;
         }
     }
 

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -25,7 +25,7 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
                 uppercaseComment += '\\';
             }
             comment += c;
-            uppercaseComment += std::toupper(c);
+            uppercaseComment += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
         } else if (quote == '\0' && (c == '\'' || c == '"')) {
             quote = c;

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -32,6 +32,11 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
     std::string_view trimmedLine = trim(line);
 
     if (trimmedLine.size() > 0 && trimmedLine[0] == '!') {
+        // Ignore OpenMP directives
+        if (trimmedLine.size() >= 5 && trimmedLine.substr(1, 5) == "$OMP") {
+            return std::nullopt;
+        }
+
         return escapeComment(trimmedLine);
     } else {
         return std::nullopt;

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -73,21 +73,24 @@ std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file)
         std::optional<std::string> line = extractCommentFromLine(std::string_view(content.data() + start, end - start));
 
         if (line.has_value()) {
-            comments.push_back(RawComment{i, start + 1, line.value()});
+            comments.push_back(RawComment{i, line.value()});
         }
     }
 
     return comments;
 }
 
-Comment processComment(const RawComment &rawComment, const std::string &lastStmtId) {
+Comment processComment(const RawComment &rawComment, const std::string &stmtId, std::size_t stmtLine) {
     return Comment {
         rawComment.text,
-        lastStmtId
+        stmtId,
+        stmtLine == rawComment.line
     };
 }
 
 std::string toString(const Comment &comment) {
     return "{\"text\": \"" + comment.text +
-           "\", \"stmtId\": \"" + comment.stmtId + "\"}";
+           "\", \"stmtId\": \"" + comment.stmtId +
+           "\", \"trailing\": " + (comment.trailing ? "true" : "false") +
+           "}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -37,9 +37,9 @@ std::optional<std::string> extractCommentFromLine(std::string_view line) {
     }
 }
 
-std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file) {
+std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file) {
     llvm::ArrayRef<char> content = file.content();
-    std::vector<Comment> comments;
+    std::vector<RawComment> comments;
 
     for (size_t i = 1; i <= file.lines(); i++) {
         std::size_t start = file.GetLineStartOffset(i);
@@ -51,15 +51,25 @@ std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file) {
         std::optional<std::string> line = extractCommentFromLine(std::string_view(content.data() + start, end - start));
 
         if (line.has_value()) {
-            comments.push_back(Comment{i, start + 1, line.value()});
+            comments.push_back(RawComment{i, start + 1, line.value()});
         }
     }
 
     return comments;
 }
 
+Comment processComment(const RawComment &rawComment, const std::string &parentId, const std::string &beforeId) {
+    return Comment {
+        rawComment.line,
+        rawComment.text,
+        parentId,
+        beforeId
+    };
+}
+
 std::string toString(const Comment &comment) {
     return "{\"line\": " + std::to_string(comment.line) +
-           ", \"column\": " + std::to_string(comment.column) +
-           ", \"text\": \"" + comment.text + "\"}";
+           ", \"text\": \"" + comment.text + "\"," +
+           ", \"parentId\": \"" + comment.parentId + "\"," +
+           ", \"beforeId\": \"" + comment.beforeId + "\"}";
 }

--- a/src/comments.cpp
+++ b/src/comments.cpp
@@ -1,6 +1,7 @@
 #include "comments.h"
 
 #include <optional>
+#include <unordered_set>
 
 #include "flang/Parser/parse-tree.h"
 
@@ -39,11 +40,16 @@ inline std::string toUppercase(const std::string_view& s)
 }
 
 std::optional<std::string> extractCommentFromLine(std::string_view line) {
+    // Add more if needed
+    static const std::unordered_set<std::string> DIRECTIVE_PREFIXES = {
+        "$OMP", "$ACC", "DIR$", "DEC$", "GCC$"
+    };
+
     std::string_view trimmedLine = trim(line);
 
     if (trimmedLine.size() > 0 && trimmedLine[0] == '!') {
-        // Ignore OpenMP directives
-        if (trimmedLine.size() >= 5 && toUppercase(trimmedLine.substr(1, 4)) == "$OMP") {
+        // Ignore directives
+        if (trimmedLine.size() >= 5 && DIRECTIVE_PREFIXES.count(toUppercase(trimmedLine.substr(1, 4))) == 1) {
             return std::nullopt;
         }
 

--- a/src/comments.h
+++ b/src/comments.h
@@ -9,17 +9,17 @@
 
 struct RawComment {
     size_t line;
-    size_t column;  // TODO(Process-ing): See if this is necessary
     std::string text;
 };
 
 struct Comment {
     std::string text;
     std::string stmtId;
+    bool trailing;
 };
 
 std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file);
-Comment processComment(const RawComment &rawComment, const std::string &stmtId);
+Comment processComment(const RawComment &rawComment, const std::string &stmtId, std::size_t stmtLine);
 std::string toString(const Comment& comment);
 
 #endif  // __COMMENTS_H__

--- a/src/comments.h
+++ b/src/comments.h
@@ -1,0 +1,19 @@
+#ifndef __COMMENTS_H__
+#define __COMMENTS_H__
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "flang/Parser/source.h"
+
+struct Comment {
+    size_t line;
+    size_t column;
+    std::string_view text;
+};
+
+std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file);
+std::string toString(const Comment& comment);
+
+#endif  // __COMMENTS_H__

--- a/src/comments.h
+++ b/src/comments.h
@@ -7,13 +7,21 @@
 
 #include "flang/Parser/source.h"
 
-struct Comment {
+struct RawComment {
     size_t line;
     size_t column;  // TODO(Process-ing): See if this is necessary
     std::string text;
 };
 
-std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file);
+struct Comment {
+    size_t line;
+    std::string text;
+    std::string parentId;
+    std::string beforeId;
+};
+
+std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file);
+Comment processComment(const RawComment &rawComment, const std::string &parentId, const std::string &beforeId);
 std::string toString(const Comment& comment);
 
 #endif  // __COMMENTS_H__

--- a/src/comments.h
+++ b/src/comments.h
@@ -10,6 +10,7 @@
 struct RawComment {
     size_t line;
     std::string text;
+    size_t sepsBefore;  // Number of semicolons before the comment on the same line
 };
 
 struct Comment {

--- a/src/comments.h
+++ b/src/comments.h
@@ -14,7 +14,6 @@ struct RawComment {
 };
 
 struct Comment {
-    size_t line;
     std::string text;
     std::string parentId;
     std::string beforeId;

--- a/src/comments.h
+++ b/src/comments.h
@@ -9,8 +9,8 @@
 
 struct Comment {
     size_t line;
-    size_t column;
-    std::string_view text;
+    size_t column;  // TODO(Process-ing): See if this is necessary
+    std::string text;
 };
 
 std::vector<Comment> extractComments(const Fortran::parser::SourceFile &file);

--- a/src/comments.h
+++ b/src/comments.h
@@ -15,12 +15,11 @@ struct RawComment {
 
 struct Comment {
     std::string text;
-    std::string parentId;
-    std::string beforeId;
+    std::string stmtId;
 };
 
 std::vector<RawComment> extractComments(const Fortran::parser::SourceFile &file);
-Comment processComment(const RawComment &rawComment, const std::string &parentId, const std::string &beforeId);
+Comment processComment(const RawComment &rawComment, const std::string &stmtId);
 std::string toString(const Comment& comment);
 
 #endif  // __COMMENTS_H__

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -41,6 +41,8 @@ template <typename T> const char *getNodeName(const T &v) {
     return "DefaultChar";
   } else if constexpr (std::is_same_v<T, Fortran::parser::CharBlock>) {
     return "CharBlock";
+  } else if constexpr (std::is_same_v<T, Fortran::parser::CommonStmt::Block>) {
+    return "CommonStmtBlock";  // To prevent name conflicts with the other AST Block nodes
   } else {
     if constexpr (std::is_same_v<
                       decltype(Fortran::parser::ParseTreeDumper::GetNodeName(

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1190,7 +1190,11 @@ public:
   DUMP_NODE(Fortran::parser::SubmoduleStmt, {})
   DUMP_NODE(Fortran::parser::SubroutineStmt, {})
   DUMP_NODE(Fortran::parser::SubroutineSubprogram, {})
-  DUMP_NODE(Fortran::parser::SubscriptTriplet, {})
+  DUMP_NODE_MANUAL(Fortran::parser::SubscriptTriplet, {
+    dump(std::get<0>(v.t), "start");
+    dump(std::get<1>(v.t), "end");
+    dump(std::get<2>(v.t), "stride");
+  })
   DUMP_NODE(Fortran::parser::Substring, {})
   DUMP_NODE(Fortran::parser::SubstringInquiry, {})
   DUMP_NODE(Fortran::parser::SubstringRange, {})

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -286,8 +286,14 @@ template <typename... T> void dump(const std::tuple<T...> &v) {
 struct ParseTreeVisitor {
 public:
   using ThisClass = ParseTreeVisitor;
-  bool firstNodeDump = true;
-  std::vector<std::string> nodeStack;
+
+  ParseTreeVisitor(
+    const Fortran::parser::AllSources &allSources,
+    const Fortran::parser::AllCookedSources &allCooked,
+    std::vector<RawComment> &&rawComments
+  ) : allSources(allSources), allCooked(allCooked), rawComments(rawComments) {}
+
+  std::vector<Comment> &getComments() { return comments; }
 
   template <typename A> bool Pre(const A &) { return true; }
   template <typename A> void Post(const A &) { return; }
@@ -1265,6 +1271,16 @@ public:
     dump(v.controls, "controls");
     dump(v.items, "items");
   })
+
+private:
+  bool firstNodeDump = true;
+  std::vector<std::string> nodeStack;
+  std::vector<Comment> comments;
+  size_t commentIndex = 0;
+
+  const Fortran::parser::AllCookedSources& allCooked;
+  const Fortran::parser::AllSources& allSources;
+  std::vector<RawComment> rawComments;
 };
 
 class DumpAST : public Fortran::frontend::PluginParseTreeAction {
@@ -1274,7 +1290,7 @@ class DumpAST : public Fortran::frontend::PluginParseTreeAction {
     const Fortran::parser::AllSources &allSources = allCooked.allSources();
 
     // Extract comments
-    std::vector<Comment> rawComments;
+    std::vector<RawComment> rawComments;
     if (auto maybeFirst = allSources.GetFirstFileProvenance()) {
       if (const auto *sourceFile = allSources.GetSourceFile(maybeFirst->start())) {
         rawComments = extractComments(*sourceFile);
@@ -1282,11 +1298,11 @@ class DumpAST : public Fortran::frontend::PluginParseTreeAction {
     }
 
     llvm::outs() << "{\"nodes\": [\n";
-    ParseTreeVisitor visitor;
+    ParseTreeVisitor visitor(allSources, allCooked, std::move(rawComments));
     Fortran::parser::Walk(getParsing().parseTree(), visitor);
     llvm::outs() << "],\n";
     llvm::outs() << "\"comments\": [\n";
-    for (const auto &comment : rawComments) {
+    for (const auto &comment : visitor.getComments()) {
       llvm::outs() << toString(comment) << ",\n";
     }
     llvm::outs() << "],\n";

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -291,7 +291,7 @@ public:
     const Fortran::parser::AllSources &allSources,
     const Fortran::parser::AllCookedSources &allCooked,
     std::vector<RawComment> &&rawComments
-  ) : allSources(allSources), allCooked(allCooked), rawComments(rawComments) {}
+) : allCooked(allCooked), allSources(allSources), rawComments(std::move(rawComments)) {}
 
   std::vector<Comment> &getComments() { return comments; }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -317,7 +317,36 @@ public:
     // llvm::outs() << T::name() << ": " << T::value() << '\n';
   }
 
-  template <typename T> bool Pre(const Fortran::parser::Statement<T> &v) {
+  std::optional<size_t> getLine(const Fortran::parser::CharBlock &block) {
+    auto range = allCooked.GetSourcePositionRange(block);
+    return range.has_value()
+      ? std::optional<size_t>(range->first.line)
+      : std::nullopt;
+  }
+
+  void flushComments(const std::string &beforeId, const std::string &parentId) {
+    while (commentIndex < rawComments.size()) {
+      Comment comment = processComment(rawComments[commentIndex], beforeId, parentId);
+      comments.push_back(comment);
+      commentIndex++;
+    }
+  }
+
+  void flushComments(size_t beforeLine, const std::string &beforeId, const std::string &parentId) {
+    while (commentIndex < rawComments.size() && rawComments[commentIndex].line < beforeLine) {
+      Comment comment = processComment(rawComments[commentIndex], beforeId, parentId);
+      comments.push_back(comment);
+      commentIndex++;
+    }
+  }
+
+  template <typename T>
+  bool Pre(const Fortran::parser::Statement<T> &v) {
+    std::string parentId = nodeStack.back();  // The stack will never be empty, since the statement must be inside a program unit
+    if (auto line = getLine(v.source)) {
+      flushComments(*line, getId(v), parentId);
+    }
+
     DUMP_BARE_NODE({
       dump(v.statement, "statement");
       dump(v.label, "label");
@@ -326,11 +355,26 @@ public:
   }
 
   template <typename T>
+  void Post(const Fortran::parser::Statement<T> &v) {
+    nodeStack.pop_back();
+  }
+
+  template <typename T>
   bool Pre(const Fortran::parser::UnlabeledStatement<T> &v) {
+    std::string parentId = nodeStack.back();  // Same thing as for labeled statements
+    if (auto line = getLine(v.source)) {
+      flushComments(*line, getId(v), parentId);
+    }
+
     DUMP_BARE_NODE({
       dump(v.statement, "statement");
       dump(v.source, "source");
     })
+  }
+
+  template <typename T>
+  void Post(const Fortran::parser::UnlabeledStatement<T> &v) {
+    nodeStack.pop_back();
   }
 
   // See "flang/Parser/dump-parse-tree.h" for complete list of nodes and enums to dump

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1345,9 +1345,13 @@ class DumpAST : public Fortran::frontend::PluginParseTreeAction {
     ParseTreeVisitor visitor(allSources, allCooked, std::move(rawComments));
     Fortran::parser::Walk(getParsing().parseTree(), visitor);
     llvm::outs() << "],\n";
+
     llvm::outs() << "\"comments\": [\n";
     for (const auto &comment : visitor.getComments()) {
-      llvm::outs() << toString(comment) << ",\n";
+      llvm::outs() << toString(comment);
+      if (&comment != &visitor.getComments().back()) {
+        llvm::outs() << ",\n";
+      }
     }
     llvm::outs() << "],\n";
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -325,7 +325,9 @@ public:
   }
 
   void flushComments() {
-    while (commentIndex < rawComments.size()) {
+    while (comments.size() < rawComments.size()) {
+      size_t commentIndex = comments.size();
+
       Comment comment = processComment(rawComments[commentIndex], programId, 0);
       comments.push_back(comment);
       commentIndex++;
@@ -333,10 +335,19 @@ public:
   }
 
   void flushComments(const std::string &stmtId, std::size_t stmtLine) {
-    while (commentIndex < rawComments.size() && rawComments[commentIndex].line <= stmtLine) {
-      Comment comment = processComment(rawComments[commentIndex], stmtId, stmtLine);
-      comments.push_back(comment);
-      commentIndex++;
+    while (comments.size() < rawComments.size()) {
+      size_t commentIndex = comments.size();
+
+      if (rawComments[commentIndex].line < stmtLine
+        || (rawComments[commentIndex].line == stmtLine && rawComments[commentIndex].sepsBefore == 0)) {
+        Comment comment = processComment(rawComments[commentIndex], stmtId, stmtLine);
+        comments.push_back(comment);
+      } else if (rawComments[commentIndex].line == stmtLine && rawComments[commentIndex].sepsBefore > 0) {
+        rawComments[commentIndex].sepsBefore--;
+        break;
+      } else {
+        break;
+      }
     }
   }
 
@@ -1307,7 +1318,6 @@ private:
   bool firstNodeDump = true;
   std::string programId;
   std::vector<Comment> comments;
-  size_t commentIndex = 0;
 
   const Fortran::parser::AllCookedSources& allCooked;
   const Fortran::parser::AllSources& allSources;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -324,17 +324,17 @@ public:
       : std::nullopt;
   }
 
-  void flushComments(const std::string &beforeId, const std::string &parentId) {
+  void flushComments() {
     while (commentIndex < rawComments.size()) {
-      Comment comment = processComment(rawComments[commentIndex], beforeId, parentId);
+      Comment comment = processComment(rawComments[commentIndex], lastStmtId);
       comments.push_back(comment);
       commentIndex++;
     }
   }
 
-  void flushComments(size_t beforeLine, const std::string &beforeId, const std::string &parentId) {
-    while (commentIndex < rawComments.size() && rawComments[commentIndex].line < beforeLine) {
-      Comment comment = processComment(rawComments[commentIndex], beforeId, parentId);
+  void flushComments(size_t beforeLine) {
+    while (commentIndex < rawComments.size() && rawComments[commentIndex].line <= beforeLine) {
+      Comment comment = processComment(rawComments[commentIndex], lastStmtId);
       comments.push_back(comment);
       commentIndex++;
     }
@@ -342,9 +342,9 @@ public:
 
   template <typename T>
   bool Pre(const Fortran::parser::Statement<T> &v) {
-    std::string parentId = nodeStack.back();  // The stack will never be empty, since the statement must be inside a program unit
+    lastStmtId = getId(v);
     if (auto line = getLine(v.source)) {
-      flushComments(*line, getId(v), parentId);
+      flushComments(*line);
     }
 
     DUMP_BARE_NODE({
@@ -355,26 +355,11 @@ public:
   }
 
   template <typename T>
-  void Post(const Fortran::parser::Statement<T> &v) {
-    nodeStack.pop_back();
-  }
-
-  template <typename T>
   bool Pre(const Fortran::parser::UnlabeledStatement<T> &v) {
-    std::string parentId = nodeStack.back();  // Same thing as for labeled statements
-    if (auto line = getLine(v.source)) {
-      flushComments(*line, getId(v), parentId);
-    }
-
     DUMP_BARE_NODE({
       dump(v.statement, "statement");
       dump(v.source, "source");
     })
-  }
-
-  template <typename T>
-  void Post(const Fortran::parser::UnlabeledStatement<T> &v) {
-    nodeStack.pop_back();
   }
 
   // See "flang/Parser/dump-parse-tree.h" for complete list of nodes and enums to dump
@@ -1318,7 +1303,7 @@ public:
 
 private:
   bool firstNodeDump = true;
-  std::vector<std::string> nodeStack;
+  std::string lastStmtId;
   std::vector<Comment> comments;
   size_t commentIndex = 0;
 
@@ -1344,6 +1329,7 @@ class DumpAST : public Fortran::frontend::PluginParseTreeAction {
     llvm::outs() << "{\"nodes\": [\n";
     ParseTreeVisitor visitor(allSources, allCooked, std::move(rawComments));
     Fortran::parser::Walk(getParsing().parseTree(), visitor);
+    visitor.flushComments();
     llvm::outs() << "],\n";
 
     llvm::outs() << "\"comments\": [\n";

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -287,6 +287,7 @@ struct ParseTreeVisitor {
 public:
   using ThisClass = ParseTreeVisitor;
   bool firstNodeDump = true;
+  std::vector<std::string> nodeStack;
 
   template <typename A> bool Pre(const A &) { return true; }
   template <typename A> void Post(const A &) { return; }
@@ -1272,6 +1273,7 @@ class DumpAST : public Fortran::frontend::PluginParseTreeAction {
     const Fortran::parser::AllCookedSources &allCooked = getParsing().allCooked();
     const Fortran::parser::AllSources &allSources = allCooked.allSources();
 
+    // Extract comments
     std::vector<Comment> rawComments;
     if (auto maybeFirst = allSources.GetFirstFileProvenance()) {
       if (const auto *sourceFile = allSources.GetSourceFile(maybeFirst->start())) {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -10,8 +10,10 @@
 #include "flang/Parser/dump-parse-tree.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Parser/parsing.h"
+#include "flang/Parser/provenance.h"
 
 #include "plugin.h"
+#include "comments.h"
 
 template <typename T, template <typename...> class Template>
 struct is_specialization : std::false_type {};
@@ -289,10 +291,6 @@ public:
   template <typename A> bool Pre(const A &) { return true; }
   template <typename A> void Post(const A &) { return; }
 
-  template <typename T> static void dump_enum() {
-    // llvm::outs() << T::name() << ": " << T::value() << '\n';
-  }
-
   // Function to dump all registered enums as JSON
   static void dumpEnumValues() {
     const auto &reg = Collector<ThisClass>::get_registry();
@@ -305,6 +303,11 @@ public:
       first = false;
     }
     llvm::outs() << "\n";
+  }
+
+
+  template <typename T> static void dump_enum() {
+    // llvm::outs() << T::name() << ": " << T::value() << '\n';
   }
 
   template <typename T> bool Pre(const Fortran::parser::Statement<T> &v) {
@@ -1266,9 +1269,24 @@ public:
 class DumpAST : public Fortran::frontend::PluginParseTreeAction {
 
   void executeAction() override {
+    const Fortran::parser::AllCookedSources &allCooked = getParsing().allCooked();
+    const Fortran::parser::AllSources &allSources = allCooked.allSources();
+
+    std::vector<Comment> rawComments;
+    if (auto maybeFirst = allSources.GetFirstFileProvenance()) {
+      if (const auto *sourceFile = allSources.GetSourceFile(maybeFirst->start())) {
+        rawComments = extractComments(*sourceFile);
+      }
+    }
+
     llvm::outs() << "{\"nodes\": [\n";
     ParseTreeVisitor visitor;
     Fortran::parser::Walk(getParsing().parseTree(), visitor);
+    llvm::outs() << "],\n";
+    llvm::outs() << "\"comments\": [\n";
+    for (const auto &comment : rawComments) {
+      llvm::outs() << toString(comment) << ",\n";
+    }
     llvm::outs() << "],\n";
 
     llvm::outs() << "\"enums\": {\n";

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -326,15 +326,15 @@ public:
 
   void flushComments() {
     while (commentIndex < rawComments.size()) {
-      Comment comment = processComment(rawComments[commentIndex], lastStmtId);
+      Comment comment = processComment(rawComments[commentIndex], programId, 0);
       comments.push_back(comment);
       commentIndex++;
     }
   }
 
-  void flushComments(size_t beforeLine) {
-    while (commentIndex < rawComments.size() && rawComments[commentIndex].line <= beforeLine) {
-      Comment comment = processComment(rawComments[commentIndex], lastStmtId);
+  void flushComments(const std::string &stmtId, std::size_t stmtLine) {
+    while (commentIndex < rawComments.size() && rawComments[commentIndex].line <= stmtLine) {
+      Comment comment = processComment(rawComments[commentIndex], stmtId, stmtLine);
       comments.push_back(comment);
       commentIndex++;
     }
@@ -342,9 +342,9 @@ public:
 
   template <typename T>
   bool Pre(const Fortran::parser::Statement<T> &v) {
-    lastStmtId = getId(v);
+    std::string stmtId = getId(v);
     if (auto line = getLine(v.source)) {
-      flushComments(*line);
+      flushComments(stmtId, *line);
     }
 
     DUMP_BARE_NODE({
@@ -1166,7 +1166,9 @@ public:
   DUMP_NODE(Fortran::parser::ProcedureDesignator, {})
   DUMP_NODE(Fortran::parser::ProcedureStmt, {})
   DUMP_ENUM(Fortran::parser::ProcedureStmt, Kind)
-  DUMP_NODE(Fortran::parser::Program, {})
+  DUMP_NODE(Fortran::parser::Program, {
+    programId = getId(v);
+  })
   DUMP_NODE(Fortran::parser::ProgramStmt, {})
   DUMP_NODE(Fortran::parser::ProgramUnit, {})
   DUMP_NODE(Fortran::parser::Protected, { dump("Protected", "keyword"); })
@@ -1303,7 +1305,7 @@ public:
 
 private:
   bool firstNodeDump = true;
-  std::string lastStmtId;
+  std::string programId;
   std::vector<Comment> comments;
   size_t commentIndex = 0;
 

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -97,10 +97,17 @@ void dumpTuple(const T &v) { dump(v.t); }
 template <typename T>
 void dumpConstraint(const T &v) { dump(v.thing); }
 
+#define DUMP_POST(CLASS)      \
+  void Post(const CLASS &) {  \
+    nodeStack.pop_back();     \
+  }
+
 #define DUMP_PROPERTY(KEY, VALUE) \
   llvm::outs() << ",\n\"" << KEY << "\": \"" << VALUE << "\"";
 
 #define DUMP_BARE_NODE(CONTENT)                                 \
+  std::string id = getId(v);                                    \
+  nodeStack.push_back(id);                                      \
   if (!firstNodeDump)                                           \
   {                                                             \
     llvm::outs() << ",\n";                                      \
@@ -110,7 +117,7 @@ void dumpConstraint(const T &v) { dump(v.thing); }
     firstNodeDump = false;                                      \
   }                                                             \
   llvm::outs() << "{\n";                                        \
-  llvm::outs() << "\"" << "id" << "\": \"" << getId(v) << "\""; \
+  llvm::outs() << "\"" << "id" << "\": \"" << id << "\"";       \
   CONTENT;                                                      \
   llvm::outs() << "\n}";                                        \
   return true;
@@ -142,7 +149,8 @@ void dumpConstraint(const T &v) { dump(v.thing); }
                                                                     \
       CONTENTS;                                                     \
     })                                                              \
-  }
+  }                                                                 \
+  DUMP_POST(CLASS)
 
 #define DUMP_NODE_MANUAL(CLASS, CONTENTS)                                  \
   bool Pre(const CLASS &v)                                          \
@@ -150,7 +158,8 @@ void dumpConstraint(const T &v) { dump(v.thing); }
     DUMP_BARE_NODE({                                                \
       CONTENTS;                                                     \
     })                                                              \
-  }
+  }                                                                 \
+  DUMP_POST(CLASS)
 
 
 #define CONCATENATE_(X, Y) X##Y

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -97,17 +97,11 @@ void dumpTuple(const T &v) { dump(v.t); }
 template <typename T>
 void dumpConstraint(const T &v) { dump(v.thing); }
 
-#define DUMP_POST(CLASS)      \
-  void Post(const CLASS &) {  \
-    nodeStack.pop_back();     \
-  }
-
 #define DUMP_PROPERTY(KEY, VALUE) \
   llvm::outs() << ",\n\"" << KEY << "\": \"" << VALUE << "\"";
 
 #define DUMP_BARE_NODE(CONTENT)                                 \
   std::string id = getId(v);                                    \
-  nodeStack.push_back(id);                                      \
   if (!firstNodeDump)                                           \
   {                                                             \
     llvm::outs() << ",\n";                                      \
@@ -149,8 +143,7 @@ void dumpConstraint(const T &v) { dump(v.thing); }
                                                                     \
       CONTENTS;                                                     \
     })                                                              \
-  }                                                                 \
-  DUMP_POST(CLASS)
+  }
 
 #define DUMP_NODE_MANUAL(CLASS, CONTENTS)                                  \
   bool Pre(const CLASS &v)                                          \
@@ -158,8 +151,7 @@ void dumpConstraint(const T &v) { dump(v.thing); }
     DUMP_BARE_NODE({                                                \
       CONTENTS;                                                     \
     })                                                              \
-  }                                                                 \
-  DUMP_POST(CLASS)
+  }
 
 
 #define CONCATENATE_(X, Y) X##Y


### PR DESCRIPTION
# Description

This PR adds support for dumping comments into the result.

To make the representation of comments in the AST feasible, we associate each comment with the statement that immediately follows it. There are two notable exceptions to this rule:

1. If a comment is a trailing comment (immediately follows the statement in the same line), it is associated to the statement and flagged as trailing.
2. Comments at the end of the source code get associated to the program node (root) instead.

The comments are stored as objects in a new field of the main JSON (along with the nodes and enums). Each JSON representative of a comment will store the contents of the comment, the statemwent it is associated with and a flag indicating if it is trailling or not.

# Changes Made

- Added logic to parse comments from the source code, kept in `src/comments.h` and `src/comments.cpp`
- Extracted comments using source information (through the classes `Fortran::parser::AllSources` and `Fortran::parser::AllCookedSources`)
- Extended the `Statement` handler to associate all matching comments